### PR TITLE
Useragent

### DIFF
--- a/lda.R
+++ b/lda.R
@@ -13,6 +13,8 @@ library(textmineR)
 library(future.apply)
 plan(multisession)
 
+options(HTTPUserAgent="Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36")
+
 ## -------------------------------------------------------------------
 ## Loading the parliamentary archive
 


### PR DESCRIPTION
Some sites behave better when the HTTP client looks like a regular web browser. I haven't yet checked whether it makes a difference for `parlament.hu`, but maybe there will be sites where we need this.