### PR TITLE
Filename portability

### DIFF
--- a/lda.R
+++ b/lda.R
@@ -65,8 +65,10 @@ links <- parliament_archive[grep("/documents/10181/.*szám",parliament_archive)]
 ## -------------------------------------------------------------------
 ## Downloading the pdf files into the pdfs directory
 
-if (! dir.exists("./pdfs")){
-    dir.create("./pdfs")}
+pdf_directory <- file.path(getwd(), "pdfs")
+
+if (! dir.exists(pdf_directory)){
+    dir.create(pdf_directory)}
 
 
 get_url_retrying <- function(URL, outfile, attempts = 5, throttle = 5) {
@@ -103,13 +105,15 @@ download_file <- function(URL,outfile,nth,total) {
 
 download_pdfs <- function(nth, links) {
     URL <- links[[nth]][1]
-    outfile <- sprintf("./pdfs/%s",links[[nth]][2])
+    outfile <- file.path(pdf_directory, links[[nth]][2])
     total <- length(links)
     return(download_file(URL,outfile,nth,total))}
 
 
-if (! dir.exists("./results")){
-    dir.create("./results")}
+result_directory <- file.path(getwd(), "results")
+
+if (! dir.exists(result_directory)){
+    dir.create(result_directory)}
 
 ## Asynchronously downloading the pdf files
 #download_results <- 
@@ -127,14 +131,16 @@ download_results <-
                                     print(return_value)
                                     return(return_value)})
                                                     
-writeLines(unlist(download_results),"./results/download_results.txt")                                  
+writeLines(unlist(download_results), file.path(result_directory, "download_results.txt"))
 
 
 ## -------------------------------------------------------------------
 ## Converting all pdf files into txt files
 
-if (! dir.exists("./txts")){
-    dir.create("./txts")}
+txt_directory <- file.path(getwd(), "txts")
+
+if (! dir.exists(txt_directory)){
+    dir.create(txt_directory)}
 
 newline <- function (x,y) {
     if (!y) {
@@ -183,7 +189,7 @@ convert_pdf <- function(nth,pdfs) {
     return(pdf_to_txt(infile,outfile,nth,total))
     }
 
-pdfs <- Sys.glob("./pdfs/*.pdf")
+pdfs <- Sys.glob(file.path(pdf_directory, "*.pdf"))
     
 convert_results <- 
     future.apply::future_lapply(future.seed=TRUE,1:length(pdfs),
@@ -192,9 +198,9 @@ convert_results <-
                                     print(return_value)
                                     return(return_value)})
 
-writeLines(unlist(convert_results),"./results/convert_results.txt")
+writeLines(unlist(convert_results), file.path(result_directory, "convert_results.txt"))
 
-id <- Sys.glob("./txts/*.txt")
+id <- Sys.glob(file.path(txt_directory, "*.txt"))
 
 data <- sapply(id, read_file)
 


### PR DESCRIPTION
I used `file.path` to remove platform-dependent pathname syntax from the code to improve portability. Currently, the relative `"."` reference to the current working directory is replaced by an absolute reference obtained through `getwd()`. This has the disadvantage that absolute pathnames are carried all the way through the code. I haven't found a portable expression for the relative current working directory reference `"."` yet. Maybe we can also leave the first pathname component out completely (e.g. `"pdfs"` instead of `"./pdfs"` on Linux).