### PR TITLE
Cache dtm

### DIFF
--- a/lda-generic.R
+++ b/lda-generic.R
@@ -10,22 +10,30 @@ library(hunspell)
 library(SnowballC)
 library(textmineR)
 
-frame <- fromJSON(read_file("hungary.json"))
+dtm_cache_file <- "hungary-dtm.rds"
 
-stemming_function <- function (x) unlist(hunspell_stem(x,"hu_HU"))
+if (file.exists(dtm_cache_file)) {
+    dtm <- readRDS(dtm_cache_file)
+} else {
+    frame <- fromJSON(read_file("hungary.json"))
 
-dtm <- CreateDtm(
-    doc_vec = frame$data,
-    doc_names = frame$id,
-    ngram_window = c(1, 1),
-    stopword_vec = c(stopwords::stopwords("hu")),
-    lower = TRUE,
-    remove_punctuation = TRUE,
-    remove_numbers = TRUE,
-    verbose = FALSE,
-    stem_lemma_function = stemming_function,
-    cpus = parallel::detectCores()
-)
+    stemming_function <- function (x) unlist(hunspell_stem(x,"hu_HU"))
+
+    dtm <- CreateDtm(
+        doc_vec = frame$data,
+        doc_names = frame$id,
+        ngram_window = c(1, 1),
+        stopword_vec = c(stopwords::stopwords("hu")),
+        lower = TRUE,
+        remove_punctuation = TRUE,
+        remove_numbers = TRUE,
+        verbose = FALSE,
+        stem_lemma_function = stemming_function,
+        cpus = parallel::detectCores()
+    )
+
+    saveRDS(dtm, file = dtm_cache_file)
+}
 
 ## arbitrary seeding for reproducible output
 set.seed(12833)


### PR DESCRIPTION
This patch caches the DTM in an RDS file for later reuse. This should reduce computational costs when trying different LDA fitting parameters.